### PR TITLE
Fix multiline paste for firefox

### DIFF
--- a/codecake.js
+++ b/codecake.js
@@ -79,7 +79,7 @@ export const create = (parent, options = {}) => {
     if (!options?.readOnly && editor.contentEditable !== "plaintext-only") {
         editor.setAttribute("contenteditable", "true");
         editor.addEventListener("paste", event => {
-            let insertText = event.clipboardData.getData("text/plain");
+            const insertText = event.clipboardData.getData("text/plain");
             event.preventDefault()
             // insert text at cursor position
             const sel = window.getSelection();

--- a/codecake.js
+++ b/codecake.js
@@ -78,6 +78,16 @@ export const create = (parent, options = {}) => {
     // 'plaintext-only' mode is not supported in Firefox
     if (!options?.readOnly && editor.contentEditable !== "plaintext-only") {
         editor.setAttribute("contenteditable", "true");
+        editor.addEventListener("paste", event => {
+            let insertText = event.clipboardData.getData("text/plain");
+            event.preventDefault()
+            // insert text at cursor position
+            const sel = window.getSelection();
+            const range = sel.getRangeAt(0);
+            range.deleteContents();
+            range.insertNode(document.createTextNode(insertText));
+            update(10);
+        });
     }
     if (options?.lineWrap) {
         editor.classList.add("codecake-linewrapping");


### PR DESCRIPTION
Because Firefox doesn't support contenteditable="plaintext-only", pasting in multiple lines of code will cause them to all get put on the same line.
![image](https://github.com/jmjuanes/codecake/assets/76746384/34897976-06a5-4b37-93f7-dd5bd7dafb06)

This fix overrides the default paste action so that it can more or less handle multiple lines.